### PR TITLE
adding mathport dependency

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,6 +1,7 @@
 import Lake
 open Lake DSL
 
-package ZkSNARK {
-  -- add configuration options here
-}
+package ZkSNARK 
+
+require mathlib3port from git
+   "https://github.com/leanprover-community/mathlib3port.git"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-06-30
+leanprover/lean4:nightly-2022-06-13

--- a/mathporttest.lean
+++ b/mathporttest.lean
@@ -1,0 +1,16 @@
+import Mathbin.Data.MvPolynomial.Basic
+import Mathbin.Data.Polynomial.Div
+
+-- Checking some imports used in 
+-- <https://github.com/BoltonBailey/formal-snarks-project/blob/master/src/general_lemmas/mv_X_mul.lean>
+-- and
+-- <https://github.com/BoltonBailey/formal-snarks-project/blob/master/src/general_lemmas/polynomial_mv_sv_cast.lean>
+
+#check @Finsupp.single
+#check @Finset.sum_insert
+#check MvPolynomial
+#check MvPolynomial.coeff_mul_X'
+#check Finset.sum_hom_rel
+#check Polynomial.eval₂
+#check Polynomial.X_pow_eq_monomial
+#check Polynomial.monomial_zero_left


### PR DESCRIPTION
adds support for using compiled `.olean`s from `mathlib3` 

Check out `mathporttest.lean`as an example of use

```lean
import Mathbin.Data.MvPolynomial.Basic
import Mathbin.Data.Polynomial.Div

-- Checking some imports used in 
-- <https://github.com/BoltonBailey/formal-snarks-project/blob/master/src/general_lemmas/mv_X_mul.lean>
-- and
-- <https://github.com/BoltonBailey/formal-snarks-project/blob/master/src/general_lemmas/polynomial_mv_sv_cast.lean>

#check @Finsupp.single
#check @Finset.sum_insert
#check MvPolynomial
#check MvPolynomial.coeff_mul_X'
#check Finset.sum_hom_rel
#check Polynomial.eval₂
#check Polynomial.X_pow_eq_monomial
#check Polynomial.monomial_zero_left
```